### PR TITLE
[build] Enforce WORKING_DIRECTORY when initializing git submodules

### DIFF
--- a/libs/geometry.hpp.cmake
+++ b/libs/geometry.hpp.cmake
@@ -3,7 +3,8 @@ if(TARGET mapbox-base-geometry-hpp)
 endif()
 
 execute_process(
-    COMMAND git submodule update --init ${CMAKE_CURRENT_SOURCE_DIR}/geometry.hpp
+    COMMAND git submodule update --init geometry.hpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_library(mapbox-base-geometry-hpp INTERFACE)

--- a/libs/variant.cmake
+++ b/libs/variant.cmake
@@ -3,7 +3,8 @@ if(TARGET mapbox-base-variant)
 endif()
 
 execute_process(
-    COMMAND git submodule update --init ${CMAKE_CURRENT_SOURCE_DIR}/variant
+    COMMAND git submodule update --init variant
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_library(mapbox-base-variant INTERFACE)


### PR DESCRIPTION
Otherwise, when invoking this script from a repositoy in which mapbox-base is a submodule, git won't know how to handle the given path.