### PR TITLE
[build] Use CMAKE_CURRENT_LIST_DIR

### DIFF
--- a/libs/geometry.hpp.cmake
+++ b/libs/geometry.hpp.cmake
@@ -4,11 +4,11 @@ endif()
 
 execute_process(
     COMMAND git submodule update --init geometry.hpp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
 add_library(mapbox-base-geometry-hpp INTERFACE)
 
 target_include_directories(mapbox-base-geometry-hpp SYSTEM INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/geometry.hpp/include
+    ${CMAKE_CURRENT_LIST_DIR}/geometry.hpp/include
 )

--- a/libs/optional.cmake
+++ b/libs/optional.cmake
@@ -4,11 +4,11 @@ endif()
 
 execute_process(
     COMMAND git submodule update --init optional
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
 add_library(mapbox-base-optional INTERFACE)
 
 target_include_directories(mapbox-base-optional SYSTEM INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/optional
+    ${CMAKE_CURRENT_LIST_DIR}/optional
 )

--- a/libs/variant.cmake
+++ b/libs/variant.cmake
@@ -4,11 +4,11 @@ endif()
 
 execute_process(
     COMMAND git submodule update --init variant
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
 
 add_library(mapbox-base-variant INTERFACE)
 
 target_include_directories(mapbox-base-variant SYSTEM INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/variant/include
+    ${CMAKE_CURRENT_LIST_DIR}/variant/include
 )


### PR DESCRIPTION
This make the top level directory the same as the .cmake file rather than the file incluing the .cmake file.

Otherwise it breaks if you include, say, variant.cmake directly.