### PR TITLE
[base] Added mapbox/io

### DIFF
--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -3,11 +3,6 @@ function(mapbox_base_extras_add_library name include_path)
         return()
     endif()
 
-    execute_process(
-        COMMAND git submodule update --init ${name}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    )
-
     add_library(mapbox-base-extras-${name} INTERFACE)
     add_library(Mapbox::Base::Extras::${name} ALIAS mapbox-base-extras-${name})
 
@@ -20,6 +15,11 @@ endfunction()
 
 add_library(mapbox-base-extras INTERFACE)
 add_library(Mapbox::Base::Extras ALIAS mapbox-base-extras)
+
+execute_process(
+    COMMAND git submodule update --init
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)
 
 mapbox_base_extras_add_library(args ${CMAKE_CURRENT_LIST_DIR}/args)
 mapbox_base_extras_add_library(expected-lite ${CMAKE_CURRENT_LIST_DIR}/expected-lite/include)

--- a/mapbox/CMakeLists.txt
+++ b/mapbox/CMakeLists.txt
@@ -3,11 +3,6 @@ function(mapbox_base_add_library name include_path)
         return()
     endif()
 
-    execute_process(
-        COMMAND git submodule update --init ${name}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    )
-
     add_library(mapbox-base-${name} INTERFACE)
     add_library(Mapbox::Base::${name} ALIAS mapbox-base-${name})
 
@@ -21,7 +16,13 @@ endfunction()
 add_library(mapbox-base INTERFACE)
 add_library(Mapbox::Base ALIAS mapbox-base)
 
+execute_process(
+    COMMAND git submodule update --init
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)
+
 mapbox_base_add_library(geometry.hpp ${CMAKE_CURRENT_LIST_DIR}/geometry.hpp/include)
+mapbox_base_add_library(io ${CMAKE_CURRENT_LIST_DIR}/io/include)
 mapbox_base_add_library(optional ${CMAKE_CURRENT_LIST_DIR}/optional)
 mapbox_base_add_library(pixelmatch-cpp ${CMAKE_CURRENT_LIST_DIR}/pixelmatch-cpp/include)
 mapbox_base_add_library(variant ${CMAKE_CURRENT_LIST_DIR}/variant/include)

--- a/mapbox/io/LICENSE
+++ b/mapbox/io/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) MapBox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name "MapBox" nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/mapbox/io/README.md
+++ b/mapbox/io/README.md
@@ -1,0 +1,4 @@
+# mapbox-io
+Mapbox I/O file operations
+
+A collection of common I/O file operations used by our native SDKs.

--- a/mapbox/io/include/mapbox/io.hpp
+++ b/mapbox/io/include/mapbox/io.hpp
@@ -1,0 +1,73 @@
+#include <string>
+
+#include <ghc/filesystem.hpp>
+#include <nonstd/expected.hpp>
+
+#include <fstream>
+#include <sstream>
+#include <cerrno>
+#include <iostream>
+
+namespace mapbox {
+namespace util {
+
+using ErrorType = std::string;
+
+nonstd::expected<std::string, ErrorType> readFile(const ghc::filesystem::path& filename) {
+    nonstd::expected<std::string, ErrorType> result;
+
+    std::ifstream file(filename.string(), std::ios::binary);
+    if (!file.good()) {
+        return nonstd::make_unexpected(std::string("Failed to read file '") + filename.string() + std::string("'"));
+    }
+
+    std::stringstream data;
+    data << file.rdbuf();
+    result = data.str();
+    return result;
+}
+
+nonstd::expected<void, ErrorType> writeFile(const ghc::filesystem::path& filename, const std::string& data) {
+    nonstd::expected<void, ErrorType> result;
+
+    FILE *fd = fopen(filename.string().c_str(), "wb");
+    if (!fd) {
+        return nonstd::make_unexpected(std::string("Failed to write file '") + filename.string() + std::string("'"));
+    }
+
+    fwrite(data.data(), sizeof(std::string::value_type), data.size(), fd);
+    fclose(fd);
+    return result;
+}
+
+nonstd::expected<void, ErrorType> deleteFile(const ghc::filesystem::path& filename) {
+    nonstd::expected<void, ErrorType> result;
+
+    const int ret = std::remove(filename.string().c_str());
+    if (ret != 0) {
+        return nonstd::make_unexpected(std::string("Failed to delete file '") + filename.string() + std::string("'"));
+    }
+
+    return result;
+}
+
+
+nonstd::expected<void, ErrorType> copyFile(const ghc::filesystem::path& sourcePath, const ghc::filesystem::path& destinationPath) {
+    nonstd::expected<void, ErrorType> result;
+
+    std::ifstream source(sourcePath, std::ios::binary);
+    if (!source.good()) {
+        return nonstd::make_unexpected(std::string("Failed to open source file '") + sourcePath.string() + std::string("'"));
+    }
+
+    std::ofstream destination(destinationPath, std::ios::binary);
+    if (!destination.good()) {
+        return nonstd::make_unexpected(std::string("Failed to open destination file '") + destinationPath.string() + std::string("'"));
+    }
+
+    destination << source.rdbuf();
+    return result;
+}
+
+} // namespace util
+} // namespace mapbox

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,13 @@
-add_executable(include-tests-bundle ${CMAKE_CURRENT_SOURCE_DIR}/include.cpp)
+add_executable(include-test-bundle ${CMAKE_CURRENT_SOURCE_DIR}/include.cpp)
 
-target_link_libraries(include-tests-bundle PRIVATE
+target_link_libraries(include-test-bundle PRIVATE
     Mapbox::Base
     Mapbox::Base::Extras
 )
 
-add_executable(include-tests-targets ${CMAKE_CURRENT_SOURCE_DIR}/include.cpp)
+add_executable(include-test-targets ${CMAKE_CURRENT_SOURCE_DIR}/include.cpp)
 
-target_link_libraries(include-tests-targets PRIVATE
+target_link_libraries(include-test-targets PRIVATE
     Mapbox::Base::Extras::args
     Mapbox::Base::Extras::expected-lite
     Mapbox::Base::Extras::filesystem
@@ -18,5 +18,18 @@ target_link_libraries(include-tests-targets PRIVATE
     Mapbox::Base::variant
 )
 
-add_test(NAME include-tests-bundle COMMAND include-tests-bundle)
-add_test(NAME include-tests-targets COMMAND include-tests-targets)
+add_test(NAME include-test-bundle COMMAND include-test-bundle)
+add_test(NAME include-test-targets COMMAND include-test-targets)
+
+add_executable(io-test ${CMAKE_CURRENT_SOURCE_DIR}/io.cpp)
+
+target_link_libraries(io-test PRIVATE
+    Mapbox::Base::io
+    Mapbox::Base::Extras::expected-lite
+    Mapbox::Base::Extras::filesystem
+)
+
+add_test(NAME io-test COMMAND io-test)
+
+add_definitions(-DTEST_FIXTURES_PATH="${CMAKE_CURRENT_LIST_DIR}/fixtures/")
+add_definitions(-DTEST_BINARY_PATH="${CMAKE_CURRENT_BINARY_DIR}/")

--- a/test/fixtures/hello_world.txt
+++ b/test/fixtures/hello_world.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/test/io.cpp
+++ b/test/io.cpp
@@ -1,0 +1,50 @@
+#include <mapbox/io.hpp>
+
+#include <cassert>
+
+int main() {
+    ghc::filesystem::path path(std::string(TEST_BINARY_PATH) + "foo.txt");
+    ghc::filesystem::path copyPath(std::string(TEST_BINARY_PATH) + "bar.txt");
+    ghc::filesystem::path invalidPath("invalid");
+    ghc::filesystem::path unauthorizedPath("/root/unauthorized");
+
+    std::string bar("bar");
+
+    nonstd::expected<void, std::string> voidExpected = mapbox::util::writeFile(path, bar);
+    assert(voidExpected);
+
+    voidExpected = mapbox::util::writeFile(unauthorizedPath, bar);
+    assert(!voidExpected);
+    assert(voidExpected.error() == std::string("Failed to write file '/root/unauthorized'"));
+
+    nonstd::expected<std::string, std::string> stringExpected = mapbox::util::readFile(path);
+    assert(stringExpected);
+    assert(*stringExpected == bar);
+
+    stringExpected = mapbox::util::readFile(invalidPath);
+    assert(!stringExpected);
+    assert(stringExpected.error() == std::string("Failed to read file 'invalid'"));
+
+    voidExpected = mapbox::util::copyFile(path, copyPath);
+    assert(voidExpected);
+
+    voidExpected = mapbox::util::copyFile(path, unauthorizedPath);
+    assert(!voidExpected);
+    assert(voidExpected.error() == std::string("Failed to open destination file '/root/unauthorized'"));
+
+    voidExpected = mapbox::util::copyFile(invalidPath, path);
+    assert(!voidExpected);
+    assert(voidExpected.error() == std::string("Failed to open source file 'invalid'"));
+
+    voidExpected = mapbox::util::deleteFile(path);
+    assert(voidExpected);
+
+    voidExpected = mapbox::util::deleteFile(copyPath);
+    assert(voidExpected);
+
+    voidExpected = mapbox::util::deleteFile(invalidPath);
+    assert(!voidExpected);
+    assert(voidExpected.error() == std::string("Failed to delete file 'invalid'"));
+
+    return 0;
+}


### PR DESCRIPTION
Implemented `mapbox/io` as a header-only library that provides simple IO file operations: read, write, copy and delete are available at the moment.