### PR TITLE
Exclude static library from the "all" build

### DIFF
--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -28,15 +28,6 @@ execute_process(
 mapbox_base_extras_add_library(args ${CMAKE_CURRENT_LIST_DIR}/args)
 mapbox_base_extras_add_library(expected-lite ${CMAKE_CURRENT_LIST_DIR}/expected-lite/include)
 mapbox_base_extras_add_library(filesystem ${CMAKE_CURRENT_LIST_DIR}/filesystem/include)
-mapbox_base_extras_add_library(rapidjson ${CMAKE_CURRENT_LIST_DIR}/rapidjson/include)
-target_compile_definitions(mapbox-base-extras-rapidjson INTERFACE
-    RAPIDJSON_HAS_STDSTRING=1
-)
-
-if(WIN32)
-    target_compile_definitions(mapbox-base-extras-rapidjson INTERFACE
-        RAPIDJSON_HAS_CXX11_RVALUE_REFS
-    )
-endif()
-
 mapbox_base_extras_add_library(kdbush.hpp ${CMAKE_CURRENT_LIST_DIR}/kdbush.hpp/include)
+
+include(${CMAKE_CURRENT_LIST_DIR}/rapidjson.cmake)

--- a/extras/rapidjson.cmake
+++ b/extras/rapidjson.cmake
@@ -1,0 +1,11 @@
+mapbox_base_extras_add_library(rapidjson ${CMAKE_CURRENT_LIST_DIR}/rapidjson/include)
+
+target_compile_definitions(mapbox-base-extras-rapidjson INTERFACE
+    RAPIDJSON_HAS_STDSTRING=1
+)
+
+if(WIN32)
+    target_compile_definitions(mapbox-base-extras-rapidjson INTERFACE
+        RAPIDJSON_HAS_CXX11_RVALUE_REFS
+    )
+endif()

--- a/mapbox/io/CMakeLists.txt
+++ b/mapbox/io/CMakeLists.txt
@@ -2,7 +2,7 @@ if(TARGET mapbox-base-io)
     return()
 endif()
 
-add_library(mapbox-base-io STATIC ${CMAKE_CURRENT_LIST_DIR}/src/io.cpp)
+add_library(mapbox-base-io STATIC EXCLUDE_FROM_ALL ${CMAKE_CURRENT_LIST_DIR}/src/io.cpp)
 add_library(Mapbox::Base::io ALIAS mapbox-base-io)
 
 target_include_directories(mapbox-base-io SYSTEM PUBLIC


### PR DESCRIPTION
Also a small cosmetic change on rapidjson, isolating it on its own file because it is defining compilation options. 