### PR TITLE
[io] Replace filesystem with std::string for paths

### DIFF
--- a/mapbox/io/CMakeLists.txt
+++ b/mapbox/io/CMakeLists.txt
@@ -11,5 +11,4 @@ target_include_directories(mapbox-base-io SYSTEM PUBLIC
 
 target_link_libraries(mapbox-base-io PRIVATE
     Mapbox::Base::Extras::expected-lite
-    Mapbox::Base::Extras::filesystem
 )

--- a/mapbox/io/include/mapbox/io.hpp
+++ b/mapbox/io/include/mapbox/io.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ghc/filesystem.hpp>
 #include <nonstd/expected.hpp>
 
 #include <string>
@@ -11,14 +10,13 @@ namespace io {
 
 using ErrorType = std::string;
 
-nonstd::expected<std::string, ErrorType> readFile(const ghc::filesystem::path& filename);
+nonstd::expected<std::string, ErrorType> readFile(const std::string& filename);
 
-nonstd::expected<void, ErrorType> writeFile(const ghc::filesystem::path& filename, const std::string& data);
+nonstd::expected<void, ErrorType> writeFile(const std::string& filename, const std::string& data);
 
-nonstd::expected<void, ErrorType> deleteFile(const ghc::filesystem::path& filename);
+nonstd::expected<void, ErrorType> deleteFile(const std::string& filename);
 
-nonstd::expected<void, ErrorType> copyFile(const ghc::filesystem::path& sourcePath,
-                                           const ghc::filesystem::path& destinationPath);
+nonstd::expected<void, ErrorType> copyFile(const std::string& sourcePath, const std::string& destinationPath);
 
 } // namespace io
 } // namespace base

--- a/mapbox/io/src/io.cpp
+++ b/mapbox/io/src/io.cpp
@@ -9,12 +9,12 @@ namespace mapbox {
 namespace base {
 namespace io {
 
-nonstd::expected<std::string, ErrorType> readFile(const ghc::filesystem::path& filename) {
+nonstd::expected<std::string, ErrorType> readFile(const std::string& filename) {
     nonstd::expected<std::string, ErrorType> result;
 
-    std::ifstream file(filename.string(), std::ios::binary);
+    std::ifstream file(filename, std::ios::binary);
     if (!file.good()) {
-        return nonstd::make_unexpected(std::string("Failed to read file '") + filename.string() + std::string("'"));
+        return nonstd::make_unexpected(std::string("Failed to read file '") + filename + std::string("'"));
     }
 
     std::stringstream data;
@@ -23,12 +23,12 @@ nonstd::expected<std::string, ErrorType> readFile(const ghc::filesystem::path& f
     return result;
 }
 
-nonstd::expected<void, ErrorType> writeFile(const ghc::filesystem::path& filename, const std::string& data) {
+nonstd::expected<void, ErrorType> writeFile(const std::string& filename, const std::string& data) {
     nonstd::expected<void, ErrorType> result;
 
     std::ofstream file(filename, std::ios::binary);
     if (!file.good()) {
-        return nonstd::make_unexpected(std::string("Failed to write file '") + filename.string() + std::string("'"));
+        return nonstd::make_unexpected(std::string("Failed to write file '") + filename + std::string("'"));
     }
 
     file << data;
@@ -36,19 +36,18 @@ nonstd::expected<void, ErrorType> writeFile(const ghc::filesystem::path& filenam
     return result;
 }
 
-nonstd::expected<void, ErrorType> deleteFile(const ghc::filesystem::path& filename) {
+nonstd::expected<void, ErrorType> deleteFile(const std::string& filename) {
     nonstd::expected<void, ErrorType> result;
 
-    const int ret = std::remove(filename.string().c_str());
+    const int ret = std::remove(filename.c_str());
     if (ret != 0) {
-        return nonstd::make_unexpected(std::string("Failed to delete file '") + filename.string() + std::string("'"));
+        return nonstd::make_unexpected(std::string("Failed to delete file '") + filename + std::string("'"));
     }
 
     return result;
 }
 
-nonstd::expected<void, ErrorType> copyFile(const ghc::filesystem::path& sourcePath,
-                                           const ghc::filesystem::path& destinationPath) {
+nonstd::expected<void, ErrorType> copyFile(const std::string& sourcePath, const std::string& destinationPath) {
     auto contents = readFile(sourcePath);
     if (!contents) {
         return nonstd::make_unexpected(contents.error());

--- a/test/io.cpp
+++ b/test/io.cpp
@@ -1,3 +1,4 @@
+#include <ghc/filesystem.hpp>
 #include <mapbox/io.hpp>
 
 #include "io_delete.hpp"
@@ -13,14 +14,14 @@ int main() {
 
     std::string bar("bar");
 
-    nonstd::expected<void, std::string> voidExpected = mapbox::base::io::writeFile(path, bar);
+    nonstd::expected<void, std::string> voidExpected = mapbox::base::io::writeFile(path.string(), bar);
     assert(voidExpected);
 
     voidExpected = mapbox::base::io::writeFile(unauthorizedPath, bar);
     assert(!voidExpected);
     assert(voidExpected.error() == std::string("Failed to write file '/root/unauthorized'"));
 
-    nonstd::expected<std::string, std::string> stringExpected = mapbox::base::io::readFile(path);
+    nonstd::expected<std::string, std::string> stringExpected = mapbox::base::io::readFile(path.string());
     assert(stringExpected);
     assert(*stringExpected == bar);
 
@@ -28,20 +29,20 @@ int main() {
     assert(!stringExpected);
     assert(stringExpected.error() == std::string("Failed to read file 'invalid'"));
 
-    voidExpected = mapbox::base::io::copyFile(path, copyPath);
+    voidExpected = mapbox::base::io::copyFile(path.string(), copyPath);
     assert(voidExpected);
 
     stringExpected = mapbox::base::io::readFile(copyPath);
     assert(*stringExpected == bar);
 
-    voidExpected = mapbox::base::io::copyFile(path, unauthorizedPath);
+    voidExpected = mapbox::base::io::copyFile(path.string(), unauthorizedPath);
     assert(!voidExpected);
     assert(voidExpected.error() == std::string("Failed to write file '/root/unauthorized'"));
 
-    voidExpected = mapbox::base::io::copyFile(invalidPath, path);
+    voidExpected = mapbox::base::io::copyFile(invalidPath, path.string());
     assert(!voidExpected);
     assert(voidExpected.error() == std::string("Failed to read file 'invalid'"));
 
-    deleteTests(path, copyPath, invalidPath);
+    deleteTests(path.string(), copyPath, invalidPath);
     return 0;
 }

--- a/test/io_delete.cpp
+++ b/test/io_delete.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include <string>
 
-void deleteTests(const fspath& path, const fspath& copyPath, const fspath& invalidPath) {
+void deleteTests(const std::string& path, const std::string& copyPath, const std::string& invalidPath) {
     nonstd::expected<void, std::string> voidExpected;
 
     voidExpected = mapbox::base::io::deleteFile(path);

--- a/test/io_delete.hpp
+++ b/test/io_delete.hpp
@@ -1,5 +1,5 @@
 #pragma once
 
-using fspath = ghc::filesystem::path;
+#include <string>
 
-void deleteTests(const fspath& path, const fspath& copyPath, const fspath& invalidPath);
+void deleteTests(const std::string& path, const std::string& copyPath, const std::string& invalidPath);


### PR DESCRIPTION
Though it is nice to have an explicit filesystem path as part of IO's API, the fact that `filesystem` support cannot be used without exceptions makes it non-portable.