### PR TITLE
Buildsystem fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,28 @@
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+if(TARGET mapbox-base)
+    return()
+endif()
+
+cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 project(MAPBOX_BASE LANGUAGES CXX C)
 
-enable_testing()
+include(CTest)
 
-# Required to avoid warnings when setting visibility
 cmake_policy(SET CMP0063 NEW)
+
+if(NOT CMAKE_VERSION VERSION_LESS 3.13.0)
+    # Required to allow mapbox-base to depend on libraries coming from /deps
+    cmake_policy(SET CMP0079 NEW)
+endif()
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
-set (MAPBOX_BASE_EXTRAS ${CMAKE_CURRENT_LIST_DIR}/extras)
+add_subdirectory(${PROJECT_SOURCE_DIR}/extras)
+add_subdirectory(${PROJECT_SOURCE_DIR}/include)
+add_subdirectory(${PROJECT_SOURCE_DIR}/deps)
 
-if(TARGET mapbox-base)
-    return()
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_TESTING)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/test)
 endif()
-
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/extras)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/include)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/deps)
-
-if (BUILD_TESTING)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test)
-endif(BUILD_TESTING)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -15,16 +15,16 @@ endfunction()
 
 execute_process(
     COMMAND git submodule update --init
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/deps
 )
 
-mapbox_base_add_library(geojson-vt-cpp ${CMAKE_CURRENT_LIST_DIR}/geojson-vt-cpp/include)
-mapbox_base_add_library(geojson.hpp ${CMAKE_CURRENT_LIST_DIR}/geojson.hpp/include)
-mapbox_base_add_library(geometry.hpp ${CMAKE_CURRENT_LIST_DIR}/geometry.hpp/include)
-mapbox_base_add_library(jni.hpp ${CMAKE_CURRENT_LIST_DIR}/jni.hpp/include)
-mapbox_base_add_library(optional ${CMAKE_CURRENT_LIST_DIR}/optional)
-mapbox_base_add_library(pixelmatch-cpp ${CMAKE_CURRENT_LIST_DIR}/pixelmatch-cpp/include)
-mapbox_base_add_library(shelf-pack-cpp ${CMAKE_CURRENT_LIST_DIR}/shelf-pack-cpp/include)
-mapbox_base_add_library(supercluster.hpp ${CMAKE_CURRENT_LIST_DIR}/supercluster.hpp/include)
-mapbox_base_add_library(variant ${CMAKE_CURRENT_LIST_DIR}/variant/include)
-mapbox_base_add_library(cheap-ruler-cpp ${CMAKE_CURRENT_LIST_DIR}/cheap-ruler-cpp/include)
+mapbox_base_add_library(geojson-vt-cpp ${PROJECT_SOURCE_DIR}/deps/geojson-vt-cpp/include)
+mapbox_base_add_library(geojson.hpp ${PROJECT_SOURCE_DIR}/deps/geojson.hpp/include)
+mapbox_base_add_library(geometry.hpp ${PROJECT_SOURCE_DIR}/deps/geometry.hpp/include)
+mapbox_base_add_library(jni.hpp ${PROJECT_SOURCE_DIR}/deps/jni.hpp/include)
+mapbox_base_add_library(optional ${PROJECT_SOURCE_DIR}/deps/optional)
+mapbox_base_add_library(pixelmatch-cpp ${PROJECT_SOURCE_DIR}/deps/pixelmatch-cpp/include)
+mapbox_base_add_library(shelf-pack-cpp ${PROJECT_SOURCE_DIR}/deps/shelf-pack-cpp/include)
+mapbox_base_add_library(supercluster.hpp ${PROJECT_SOURCE_DIR}/deps/supercluster.hpp/include)
+mapbox_base_add_library(variant ${PROJECT_SOURCE_DIR}/deps/variant/include)
+mapbox_base_add_library(cheap-ruler-cpp ${PROJECT_SOURCE_DIR}/deps/cheap-ruler-cpp/include)

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -22,13 +22,12 @@ add_library(Mapbox::Base::Extras ALIAS mapbox-base-extras)
 
 execute_process(
     COMMAND git submodule update --init
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extras
 )
 
-mapbox_base_extras_add_library(args ${CMAKE_CURRENT_LIST_DIR}/args)
-mapbox_base_extras_add_library(expected-lite ${CMAKE_CURRENT_LIST_DIR}/expected-lite/include)
-mapbox_base_extras_add_library(filesystem ${CMAKE_CURRENT_LIST_DIR}/filesystem/include)
-mapbox_base_extras_add_library(kdbush.hpp ${CMAKE_CURRENT_LIST_DIR}/kdbush.hpp/include)
+mapbox_base_extras_add_library(args ${PROJECT_SOURCE_DIR}/extras/args)
+mapbox_base_extras_add_library(expected-lite ${PROJECT_SOURCE_DIR}/extras/expected-lite/include)
+mapbox_base_extras_add_library(filesystem ${PROJECT_SOURCE_DIR}/extras/filesystem/include)
+mapbox_base_extras_add_library(kdbush.hpp ${PROJECT_SOURCE_DIR}/extras/kdbush.hpp/include)
 
-include(${CMAKE_CURRENT_LIST_DIR}/rapidjson.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/googletest.cmake)
+include(${PROJECT_SOURCE_DIR}/extras/rapidjson.cmake)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,7 +1,10 @@
-
 add_library(mapbox-base INTERFACE)
 add_library(Mapbox::Base ALIAS mapbox-base)
 
-target_include_directories(mapbox-base SYSTEM
-    INTERFACE "${MAPBOX_BASE_EXTRAS}/expected-lite/include"
-    )
+target_include_directories(mapbox-base SYSTEM INTERFACE
+    "${PROJECT_SOURCE_DIR}/include"
+)
+
+target_link_libraries(mapbox-base INTERFACE
+    Mapbox::Base::Extras::expected-lite
+)

--- a/scripts/license-checker/package-lock.json
+++ b/scripts/license-checker/package-lock.json
@@ -608,9 +608,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.3.5",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,25 +1,26 @@
+include(${PROJECT_SOURCE_DIR}/extras/googletest.cmake)
 
-set (TEST_BINARY_PATH ${CMAKE_CURRENT_BINARY_DIR})
-configure_file(${CMAKE_CURRENT_LIST_DIR}/test_defines.hpp.in ${CMAKE_CURRENT_LIST_DIR}/test_defines.hpp)
+set(TEST_BINARY_PATH ${CMAKE_CURRENT_BINARY_DIR})
+configure_file(${PROJECT_SOURCE_DIR}/test/test_defines.hpp.in ${PROJECT_BINARY_DIR}/test_defines.hpp)
 
 function(create_test folder_name)
     set (target_name "test_${folder_name}")
-    set (curr_folder "${CMAKE_CURRENT_LIST_DIR}/${folder_name}")
-    
+    set (curr_folder "${PROJECT_SOURCE_DIR}/test/${folder_name}")
+
     file (GLOB_RECURSE test_files "${curr_folder}/*.cpp" "${curr_folder}/*.hpp")
     message (STATUS "Adding test ${target_name}")
 
-    add_executable(${target_name}  ${test_files})
-    target_link_libraries(${target_name} 
-        PRIVATE gtest_all 
-        mapbox-base
+    add_executable(${target_name} ${test_files})
+    target_link_libraries(${target_name} PRIVATE
+        Mapbox::Base
+        gtest_all
         pthread
-        )
+    )
+
     target_include_directories(${target_name} PRIVATE
             ${curr_folder}
-            ${PROJECT_SOURCE_DIR}/include
-            ${CMAKE_CURRENT_LIST_DIR}
-            )
+            ${PROJECT_BINARY_DIR}
+    )
 
     add_test(NAME ${target_name} COMMAND ${target_name} ${TEST_ARGUMENTS})
 endfunction()
@@ -28,6 +29,3 @@ create_test("compatibility")
 create_test("io")
 create_test("std")
 create_test("util")
-
-# TODO: find out why this should be explicitly specified in order to run `make test `
-add_custom_target(test-all COMMAND ${CMAKE_CTEST_COMMAND})


### PR DESCRIPTION
- Raise CMake minimum version to v3.5.1
- Replaced `MAPBOX_BASE_EXTRAS`, `CMAKE_CURRENT_LIST_DIR`, `CMAKE_CURRENT_SOURCE_DIR` usage with `PROJECT_SOURCE_DIR`
- Only build testing when building `mapbox-base` alone
- Added CMake policy to allow `mapbox-base` to depend on targets defined elsewhere
- Move `googletest.cmake` into `tests/CMakeLists.txt`
- Minor cleanups