### PR TITLE
[build] Update LICENSE.thirdparty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@
 # CMake build folder
 build/
 
+# NPM modules
+node_modules
+
 *.user

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,15 @@ jobs:
 
     script: scripts/ci/run-syntax-check.sh
 
+  - &license-check
+    state: test
+    os: linux
+    language: node_js
+    node_js:
+      - 10
+    name: License Check
+    script: scripts/check-license.sh
+
   - &test
     stage: test
     os: linux

--- a/LICENSE.thirdparty
+++ b/LICENSE.thirdparty
@@ -1,3 +1,36 @@
+Mapbox Base uses portions of googletest
+
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+
 Mapbox Base uses portions of kdbush.hpp
 
 Copyright (c) 2016, Vladimir Agafonkin
@@ -243,6 +276,46 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 
+Mapbox Base uses portions of cheap-ruler-cpp
+
+ISC License
+
+Copyright (c) 2017, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+===========================================================================
+
+Mapbox Base uses portions of geojson-vt-cpp
+
+ISC License
+
+Copyright (c) 2015, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+
+===========================================================================
+
 Mapbox Base uses portions of geojson.hpp
 
 Copyright (c) 2016, Mapbox
@@ -280,6 +353,26 @@ PERFORMANCE OF THIS SOFTWARE.
 
 The above license excludes the files test/android/jni.h and test/openjdk/jni.h, which are
 included for testing purposes and covered by their respective copyrights and licenses.
+
+===========================================================================
+
+Mapbox Base uses portions of shelf-pack-cpp
+
+ISC License
+
+Copyright (c) 2017, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
 
 ===========================================================================
 

--- a/license-lock
+++ b/license-lock
@@ -1,5 +1,11 @@
 [
   {
+    "path": "extras/googletest",
+    "licenseFile": "LICENSE",
+    "hash": "9702de7e4117a8e2b20dafab11ffda58c198aede066406496bef670d40a22138",
+    "action": "file"
+  },
+  {
     "path": "extras/kdbush.hpp",
     "licenseFile": "LICENSE",
     "hash": "eeb9c9d04d930512cec46a5d7c08f418af9fbc50ebf481f09fcebcdf3fbb941c",
@@ -24,19 +30,19 @@
     "action": "file"
   },
   {
-    "path": "mapbox/geometry.hpp",
+    "path": "deps/geometry.hpp",
     "licenseFile": "LICENSE",
     "hash": "44b7f71c4d7f3da85e5e6a5d0cfa6942055d326a24f4d60a3728ebed26ea2b9d",
     "action": "file"
   },
   {
-    "path": "mapbox/optional",
+    "path": "deps/optional",
     "licenseFile": "LICENSE",
     "hash": "c9bff75738922193e67fa726fa225535870d2aa1059f91452c411736284ad566",
     "action": "file"
   },
   {
-    "path": "mapbox/pixelmatch-cpp",
+    "path": "deps/pixelmatch-cpp",
     "licenseFile": "LICENSE.txt",
     "hash": "6c7e3e75cd5368e6a552a2e94db1a50080c0b2972d1d2364144227b047a6e18c",
     "action": "file"
@@ -48,45 +54,45 @@
     "action": "file"
   },
   {
-    "path": "mapbox/variant",
+    "path": "deps/variant",
     "licenseFile": "LICENSE",
     "hash": "7686f81e580cd6774f609a2d8a41b2cebdf79bc30e6b46c3efff5a656158981c",
     "action": "file"
   },
   {
-    "path": "mapbox/geojson.hpp",
+    "path": "deps/cheap-ruler-cpp",
+    "licenseFile": "LICENSE",
+    "hash": "27043d1a6a0e1985fde12660decbbd3b23c67de900b00609c90d4f0aa492f425",
+    "action": "file"
+  },
+  {
+    "path": "deps/geojson-vt-cpp",
+    "licenseFile": "LICENSE",
+    "hash": "828f2aed51b6526881a236758ec9b08cd69928fbfc70346d9d44a0b3a3444fe1",
+    "action": "file"
+  },
+  {
+    "path": "deps/geojson.hpp",
     "licenseFile": "LICENSE",
     "hash": "e2bf3affd357261f7451bb19108281c1bde54746bfa2beb0c1c34ab042b21700",
     "action": "file"
   },
   {
-    "path": "mapbox/jni.hpp",
+    "path": "deps/jni.hpp",
     "licenseFile": "LICENSE.txt",
     "hash": "640f62b4b6e940645b96d12416e6db84ed191ebcfd10c3a0ccc9a1338f222726",
     "action": "file"
   },
   {
-    "path": "mapbox/supercluster.hpp",
+    "path": "deps/shelf-pack-cpp",
+    "licenseFile": "LICENSE.md",
+    "hash": "27043d1a6a0e1985fde12660decbbd3b23c67de900b00609c90d4f0aa492f425",
+    "action": "file"
+  },
+  {
+    "path": "deps/supercluster.hpp",
     "licenseFile": "LICENSE",
     "hash": "e2bf3affd357261f7451bb19108281c1bde54746bfa2beb0c1c34ab042b21700",
-    "action": "file"
-  },
-  {
-    "path": "mapbox/io",
-    "licenseFile": "LICENSE",
-    "hash": "7686f81e580cd6774f609a2d8a41b2cebdf79bc30e6b46c3efff5a656158981c",
-    "action": "file"
-  },
-  {
-    "path": "mapbox/typewrapper",
-    "licenseFile": "LICENSE",
-    "hash": "7686f81e580cd6774f609a2d8a41b2cebdf79bc30e6b46c3efff5a656158981c",
-    "action": "file"
-  },
-  {
-    "path": "mapbox/weak",
-    "licenseFile": "LICENSE",
-    "hash": "7686f81e580cd6774f609a2d8a41b2cebdf79bc30e6b46c3efff5a656158981c",
     "action": "file"
   }
 ]

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+ROOT_PATH=$PWD
+LICENSE_CHECKER_PATH=$PWD/scripts/license-checker
+
+cd $LICENSE_CHECKER_PATH
+npm ci
+./license-checker generate $ROOT_PATH > $ROOT_PATH/license-lock && git diff --exit-code
+./license-checker license "Mapbox Base" $ROOT_PATH > $ROOT_PATH/LICENSE.thirdparty && git diff --exit-code


### PR DESCRIPTION
This PR:
- Updates `LICENSE.thirdparty` and `license-lock` to include recent additions e.g. googletest, cheap-ruler-cpp, geojson-vt-cpp, shelf-pack-cpp
- Adds `scripts/check-license.sh` together with a CI job `license-checker` to make sure we always update `LICENSE.thirdparty` when new dependencies are added