### PR TITLE
Bump expected-lite to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Mapbox Base
 
-## master
+## v1.4.0
 
 ### ✨ New features
 - [extras] Bump googletest to 1.10.0
     - Better gmock syntax.
+
+### ⚠️ Breaking changes
+- [base] expected-lite @ v0.4.0
+
+### 💫️ Other
+- [doc] Add documentation for `mapbox::base::Value`
 
 ## v1.3.0
 


### PR DESCRIPTION
Fixes a problem with movable types.