### PR TITLE
Restrict git submodule updates to the intended directory

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -14,7 +14,7 @@ function(mapbox_base_add_library name include_path)
 endfunction()
 
 execute_process(
-    COMMAND git submodule update --init
+    COMMAND git submodule update --init .
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/deps
 )
 

--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(mapbox-base-extras INTERFACE)
 add_library(Mapbox::Base::Extras ALIAS mapbox-base-extras)
 
 execute_process(
-    COMMAND git submodule update --init
+    COMMAND git submodule update --init .
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/extras
 )
 


### PR DESCRIPTION
It looks like we intended to restrict it to the directory by setting the working dir, but if there's no path included, git will update all submodules in the repo.

This lowers execution time by ~4 seconds on my machine.