### PR TITLE
Update supercluster to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Mapbox Base
 
-## next
+## v1.8.0
+
+### 💫️ Other
+ - [deps] Update supercluster.hpp to v0.5.0
 
 ## v1.7.0
 


### PR DESCRIPTION
Update  supercluster to v0.5.0. New supercluster.hpp has `generateId` feature that is backported from supercluster.js