### PR TITLE
[TypeWrapper] Add thread-safe primitives

### DIFF
--- a/include/mapbox/util/type_wrapper.hpp
+++ b/include/mapbox/util/type_wrapper.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <type_traits>
 #include <utility>
 
@@ -9,9 +10,25 @@ namespace base {
 
 class TypeWrapper {
 public:
+    using Guard = std::unique_lock<std::mutex>;
+
     TypeWrapper() noexcept : storage_(nullptr, noop_deleter) {}
-    TypeWrapper(TypeWrapper&&) noexcept = default;
-    TypeWrapper& operator=(TypeWrapper&&) noexcept = default;
+
+    TypeWrapper(TypeWrapper&& other) : storage_(nullptr, noop_deleter) {
+        std::lock_guard<std::mutex> lock(other.mutex_);
+        storage_ = std::move(other.storage_);
+    }
+
+    TypeWrapper& operator=(TypeWrapper&& other) {
+        if (this != &other) {
+            std::lock(mutex_, other.mutex_);
+            std::lock_guard<std::mutex> lock1(mutex_, std::adopt_lock);
+            std::lock_guard<std::mutex> lock2(other.mutex_, std::adopt_lock);
+
+            storage_ = std::move(other.storage_);
+        }
+        return *this;
+    }
 
     template <typename T> // NOLINTNEXTLINE misc-forwarding-reference-overload
     TypeWrapper(T&& value) noexcept
@@ -19,11 +36,22 @@ public:
         static_assert(!std::is_same<TypeWrapper, std::decay_t<T>>::value, "TypeWrapper must not wrap itself.");
     }
 
-    bool has_value() const noexcept { return static_cast<bool>(storage_); }
+    bool has_value() const noexcept {
+        return static_cast<bool>(storage_);
+    }
 
+    template <typename T>
+    void set(T&& value) {
+        static_assert(!std::is_same<TypeWrapper, std::decay_t<T>>::value, "TypeWrapper must not wrap itself.");
+        storage_ = std::unique_ptr<void, void (*)(void*)>(new std::decay_t<T>(std::forward<T>(value)), cast_deleter<std::decay_t<T>>);
+    }
     template <typename T>
     T& get() noexcept { // NOLINTNEXTLINE cppcoreguidelines-pro-type-reinterpret-cast
         return *reinterpret_cast<T*>(storage_.get());
+    }
+
+    Guard lock() {
+        return Guard(mutex_);
     }
 
 private:
@@ -35,6 +63,7 @@ private:
 
     using storage_t = std::unique_ptr<void, void (*)(void*)>;
     storage_t storage_;
+    mutable std::mutex mutex_;
 };
 
 } // namespace base


### PR DESCRIPTION
This commit adds locking primitives to TypeWrapper to allow its value to
be set in a thread-safe way. A new method, lock(), returns a guard that
keeps the wrapper object locked, allowing other methods to be
synchronized. The move constructor and move-assignment operators are
updated so they are synchronized properly.

Method set() is added to update the wrapped object without invoking the
move constructor, since the former cannot be called while holding a
TypeWrapper::Guard. The move constructor would attempt to lock again,
causing a deadlock.