### PR TITLE
Add polyfill expected type to mbx namespace

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(Mapbox::Base ALIAS mapbox-base)
 
 target_include_directories(mapbox-base SYSTEM INTERFACE
     "${PROJECT_SOURCE_DIR}/include"
+    "${PROJECT_SOURCE_DIR}/include/mapbox/polyfills"
 )
 
 target_link_libraries(mapbox-base INTERFACE

--- a/include/mapbox/polyfills/mbx/expected.hpp
+++ b/include/mapbox/polyfills/mbx/expected.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <nonstd/expected.hpp>
+
+namespace mbx {
+
+template <typename T, typename E>
+using expected = nonstd::expected<T, E>;
+
+template <typename E>
+auto make_unexpected(E&& value) {
+    return nonstd::make_unexpected<E>(std::forward<E>(value));
+}
+
+} // namespace mbx


### PR DESCRIPTION
Bring `nonstd::expected` to namespace `mbx`, which simplifies access to this type, and makes the code easier to read.